### PR TITLE
Feature 3: MinHashGenerator

### DIFF
--- a/datasketch/__init__.py
+++ b/datasketch/__init__.py
@@ -1,5 +1,5 @@
 from datasketch.hyperloglog import HyperLogLog, HyperLogLogPlusPlus
-from datasketch.minhash import MinHash
+from datasketch.minhash import MinHash, MinHashGenerator
 from datasketch.b_bit_minhash import bBitMinHash
 from datasketch.lsh import MinHashLSH
 from datasketch.weighted_minhash import WeightedMinHash, WeightedMinHashGenerator

--- a/docsrc/documentation.rst
+++ b/docsrc/documentation.rst
@@ -9,6 +9,11 @@ MinHash
     :members:
     :special-members:
 
+.. autoclass:: datasketch.MinHashGenerator
+    :members:
+    :special-members:
+
+
 Lean MinHash
 ------------
 

--- a/docsrc/minhash.rst
+++ b/docsrc/minhash.rst
@@ -74,3 +74,22 @@ cardinality. The analysis is presented in `Cohen
 If you are handling billions of MinHash objects, consider using 
 :class:`datasketch.LeanMinHash` to reduce your memory footprint.
 
+If you want to rapidly create concordant :class:`datasktech.MinHash` objects
+from a corpus of documents, use the :class:`datasketch.MinHashGenerator`:
+
+.. code:: python
+
+    from datasketch import MinHashGenerator
+
+    data1 = ['minhash', 'is', 'a', 'probabilistic', 'data', 'structure', 'for',
+            'estimating', 'the', 'similarity', 'between', 'datasets']
+    data2 = ['minhash', 'is', 'a', 'probability', 'data', 'structure', 'for',
+            'estimating', 'the', 'similarity', 'between', 'documents']
+
+    g = MinHashGenerator(num_perm=256)
+    m1 = g.create(data1)
+    m2 = g.create(data2)
+    print("Estimated Jaccard for data1 and data2 is", m1.jaccard(m2))
+
+Importantly, this obviates recalculation of the random permutations for each
+new :class:`datasketch.MinHash`.

--- a/examples/minhash_examples.py
+++ b/examples/minhash_examples.py
@@ -2,8 +2,7 @@
 Some examples for MinHash
 '''
 
-from hashlib import sha1
-from datasketch.minhash import MinHash
+from datasketch.minhash import MinHash, MinHashGenerator
 
 data1 = ['minhash', 'is', 'a', 'probabilistic', 'data', 'structure', 'for',
         'estimating', 'the', 'similarity', 'between', 'datasets']
@@ -25,5 +24,13 @@ def eg1():
             float(len(s1.union(s2)))
     print("Actual Jaccard for data1 and data2 is", actual_jaccard)
 
+
+def eg2():
+    g = MinHashGenerator()
+    m1 = g.create(data1)
+    m2 = g.create(data2)
+    print("Estimated Jaccard for data1 and data2 is", m1.jaccard(m2))
+
 if __name__ == "__main__":
     eg1()
+    eg2()

--- a/test/minhash_test.py
+++ b/test/minhash_test.py
@@ -1,10 +1,10 @@
 import unittest
 import struct
 import pickle
-from hashlib import sha1
 import numpy as np
 from datasketch import minhash
 from datasketch.b_bit_minhash import bBitMinHash
+
 
 class FakeHash(object):
     '''
@@ -29,6 +29,13 @@ class TestMinHash(unittest.TestCase):
     def test_init(self):
         m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
         m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
+        self.assertTrue(np.array_equal(m1.hashvalues, m2.hashvalues))
+        self.assertTrue(np.array_equal(m1.permutations, m2.permutations))
+
+    def test_generate(self):
+        g = minhash.MinHashGenerator(4, 1, hashobj=FakeHash)
+        m1 = g.create(['a', 'e', 'i', 'o', 'u'])
+        m2 = g.create(['a', 'e', 'i', 'o', 'u'])
         self.assertTrue(np.array_equal(m1.hashvalues, m2.hashvalues))
         self.assertTrue(np.array_equal(m1.permutations, m2.permutations))
 
@@ -111,7 +118,7 @@ class TestMinHash(unittest.TestCase):
         m.update(b'Hello')
         self.assertListEqual(
             m.hashvalues.tolist(),
-            [734825475, 960773806, 359816889, 342714745],
+            [2814212640, 3091661445, 3859323165, 1984368834],
         )
 
 class TestbBitMinHash(unittest.TestCase):


### PR DESCRIPTION
For rapid generation of concordant `MinHash` objects, saving the user from doing encoding of strings and copying across permutations (which is fiddly)